### PR TITLE
matplotlib dependency soft package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ setup(
     author_email='tgym@prediction-machines.com',
     url='https://github.com/prediction-machines/tgym',
     packages=find_packages(),
-    install_requires=[
-        'matplotlib==2.0.2'
-    ],
+    install_requires=['matplotlib'],
     license="MIT license",
     zip_safe=False,
     keywords='tgym'


### PR DESCRIPTION
It is not required to have a hard `matplotlib` version for install.
Removing this hard version dependency makes it compatible with newer python environments.